### PR TITLE
Adjust Login screen

### DIFF
--- a/app/src/main/java/com/priyank/drdelivery/authentication/presentation/AuthenticationScreen.kt
+++ b/app/src/main/java/com/priyank/drdelivery/authentication/presentation/AuthenticationScreen.kt
@@ -66,20 +66,16 @@ fun AuthenticationScreen(
         verticalArrangement = Arrangement.SpaceEvenly
     ) {
 
-        HorizontalPager(state = pagerState, modifier = Modifier.fillMaxWidth()) { page ->
-
+        HorizontalPager(state = pagerState, modifier = Modifier.fillMaxWidth().weight(1f)) { page ->
             Slider(info = viewModel.data()[page])
-
-            HorizontalPagerIndicator(
-
-                pagerState = pagerState,
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(top = 700.dp),
-                indicatorShape = RectangleShape,
-                activeColor = DarkBlue, inactiveColor = LightBlue
-            )
         }
+
+        HorizontalPagerIndicator(
+            pagerState = pagerState,
+            indicatorShape = RectangleShape,
+            activeColor = DarkBlue, inactiveColor = LightBlue
+        )
+
         LaunchedEffect(key1 = pagerState.currentPage) {
             launch {
                 delay(3000)
@@ -98,6 +94,7 @@ fun AuthenticationScreen(
         }
 
         SignInButton(
+            modifier = Modifier.padding(vertical = 16.dp),
             text = "Sign in with Google",
             loadingText = "Signing in...",
             isLoading = false,

--- a/app/src/main/java/com/priyank/drdelivery/authentication/presentation/GoogleLoginButton.kt
+++ b/app/src/main/java/com/priyank/drdelivery/authentication/presentation/GoogleLoginButton.kt
@@ -27,6 +27,7 @@ import com.priyank.drdelivery.ui.theme.Shapes
 
 @Composable
 fun SignInButton(
+    modifier: Modifier = Modifier,
     onClick: () -> Unit,
     text: String,
     loadingText: String = "Signing in...",
@@ -39,7 +40,7 @@ fun SignInButton(
 
 ) {
     Surface(
-        Modifier.clickable(
+        modifier = modifier.clickable(
             onClick = onClick
         ),
         shape = shape,

--- a/app/src/main/java/com/priyank/drdelivery/authentication/presentation/Slider.kt
+++ b/app/src/main/java/com/priyank/drdelivery/authentication/presentation/Slider.kt
@@ -26,7 +26,7 @@ fun Slider(info: Info) {
         Text(
             text = info.title,
             modifier = Modifier
-                .padding(bottom = 40.dp),
+                .padding(start = 16.dp, end = 16.dp, bottom = 40.dp),
             fontFamily = Lato,
             fontSize = 20.sp, textAlign = TextAlign.Center
         )


### PR DESCRIPTION
Test on emulator Pixel 4 - API 27

## Changed
- Add horizontal space to text in pager
- Add bottom space to sign in button 
- Move pager indicator away from the pager, because it's not part of each pages.

### Before
[before.webm](https://user-images.githubusercontent.com/13198470/196481724-153dc4b6-dee2-4aef-8648-a6f2ed8e6502.webm)

### After
[after.webm](https://user-images.githubusercontent.com/13198470/196481739-8fddc2c8-a7cc-4fb0-b07d-6b653b6ecdbb.webm)
